### PR TITLE
For UpdateRequests to have a id field

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -2831,6 +2831,13 @@ having a direct membership within the tenant.</p></td>
             <tbody>
               
                 <tr>
+                  <td>id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Id of the filesystemLayout to update </p></td>
+                </tr>
+              
+                <tr>
                   <td>filesystem_layout</td>
                   <td><a href="#metalstack.api.v2.FilesystemLayout">metalstack.api.v2.FilesystemLayout</a></td>
                   <td></td>
@@ -3448,6 +3455,13 @@ should contain os and major.minor then latest patch version of this os is return
             <tbody>
               
                 <tr>
+                  <td>id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Id of the imageLayout to update </p></td>
+                </tr>
+              
+                <tr>
                   <td>image</td>
                   <td><a href="#metalstack.api.v2.Image">metalstack.api.v2.Image</a></td>
                   <td></td>
@@ -4049,7 +4063,7 @@ Will be equal with project most of the time </p></td>
             <tbody>
               
                 <tr>
-                  <td>ip</td>
+                  <td>id</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>Ip the ip to update </p></td>
@@ -6415,6 +6429,13 @@ not in the machine state &#34;available&#34;, e.g. locked or reserved. </p></td>
             <tbody>
               
                 <tr>
+                  <td>id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>The id of the partition to update </p></td>
+                </tr>
+              
+                <tr>
                   <td>partition</td>
                   <td><a href="#metalstack.api.v2.Partition">metalstack.api.v2.Partition</a></td>
                   <td></td>
@@ -7288,10 +7309,10 @@ console.metalstack.cloud/invite/&lt;secret&gt; </p></td>
             <tbody>
               
                 <tr>
-                  <td>login</td>
+                  <td>id</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>Login of the tenant </p></td>
+                  <td><p>Login of the tenant to update </p></td>
                 </tr>
               
                 <tr>
@@ -8109,7 +8130,7 @@ for which the methods should be allowed </p></td>
             <tbody>
               
                 <tr>
-                  <td>uuid</td>
+                  <td>id</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
                   <td><p>Uuid of the token to update </p></td>
@@ -9698,10 +9719,17 @@ console.metalstack.cloud/invite/&lt;secret&gt; </p></td>
             <tbody>
               
                 <tr>
+                  <td>id</td>
+                  <td><a href="#string">string</a></td>
+                  <td></td>
+                  <td><p>Id is the uuid of the project to update, must be equal to project </p></td>
+                </tr>
+              
+                <tr>
                   <td>project</td>
                   <td><a href="#string">string</a></td>
                   <td></td>
-                  <td><p>Project is the uuid of the project to get </p></td>
+                  <td><p>Project is the uuid of the project to update </p></td>
                 </tr>
               
                 <tr>

--- a/go/metalstack/admin/v2/filesystem.pb.go
+++ b/go/metalstack/admin/v2/filesystem.pb.go
@@ -118,8 +118,10 @@ func (x *FilesystemServiceCreateResponse) GetFilesystemLayout() *v2.FilesystemLa
 // FilesystemServiceUpdateRequest
 type FilesystemServiceUpdateRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
+	// Id of the filesystemLayout to update
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// FilesystemLayout the filesystemlayout
-	FilesystemLayout *v2.FilesystemLayout `protobuf:"bytes,1,opt,name=filesystem_layout,json=filesystemLayout,proto3" json:"filesystem_layout,omitempty"`
+	FilesystemLayout *v2.FilesystemLayout `protobuf:"bytes,2,opt,name=filesystem_layout,json=filesystemLayout,proto3" json:"filesystem_layout,omitempty"`
 	unknownFields    protoimpl.UnknownFields
 	sizeCache        protoimpl.SizeCache
 }
@@ -152,6 +154,13 @@ func (x *FilesystemServiceUpdateRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use FilesystemServiceUpdateRequest.ProtoReflect.Descriptor instead.
 func (*FilesystemServiceUpdateRequest) Descriptor() ([]byte, []int) {
 	return file_metalstack_admin_v2_filesystem_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *FilesystemServiceUpdateRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
 }
 
 func (x *FilesystemServiceUpdateRequest) GetFilesystemLayout() *v2.FilesystemLayout {
@@ -307,9 +316,11 @@ const file_metalstack_admin_v2_filesystem_proto_rawDesc = "" +
 	"\x1eFilesystemServiceCreateRequest\x12P\n" +
 	"\x11filesystem_layout\x18\x01 \x01(\v2#.metalstack.api.v2.FilesystemLayoutR\x10filesystemLayout\"s\n" +
 	"\x1fFilesystemServiceCreateResponse\x12P\n" +
-	"\x11filesystem_layout\x18\x01 \x01(\v2#.metalstack.api.v2.FilesystemLayoutR\x10filesystemLayout\"r\n" +
-	"\x1eFilesystemServiceUpdateRequest\x12P\n" +
-	"\x11filesystem_layout\x18\x01 \x01(\v2#.metalstack.api.v2.FilesystemLayoutR\x10filesystemLayout\"s\n" +
+	"\x11filesystem_layout\x18\x01 \x01(\v2#.metalstack.api.v2.FilesystemLayoutR\x10filesystemLayout\"\x8e\x01\n" +
+	"\x1eFilesystemServiceUpdateRequest\x12\x1a\n" +
+	"\x02id\x18\x01 \x01(\tB\n" +
+	"\xbaH\ar\x05\x10\x02\x18\x80\x01R\x02id\x12P\n" +
+	"\x11filesystem_layout\x18\x02 \x01(\v2#.metalstack.api.v2.FilesystemLayoutR\x10filesystemLayout\"s\n" +
 	"\x1fFilesystemServiceUpdateResponse\x12P\n" +
 	"\x11filesystem_layout\x18\x01 \x01(\v2#.metalstack.api.v2.FilesystemLayoutR\x10filesystemLayout\"<\n" +
 	"\x1eFilesystemServiceDeleteRequest\x12\x1a\n" +

--- a/go/metalstack/admin/v2/image.pb.go
+++ b/go/metalstack/admin/v2/image.pb.go
@@ -118,8 +118,10 @@ func (x *ImageServiceCreateResponse) GetImage() *v2.Image {
 // ImageServiceUpdateRequest
 type ImageServiceUpdateRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
+	// Id of the imageLayout to update
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Image is the image
-	Image         *v2.Image `protobuf:"bytes,1,opt,name=image,proto3" json:"image,omitempty"`
+	Image         *v2.Image `protobuf:"bytes,2,opt,name=image,proto3" json:"image,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -152,6 +154,13 @@ func (x *ImageServiceUpdateRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ImageServiceUpdateRequest.ProtoReflect.Descriptor instead.
 func (*ImageServiceUpdateRequest) Descriptor() ([]byte, []int) {
 	return file_metalstack_admin_v2_image_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *ImageServiceUpdateRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
 }
 
 func (x *ImageServiceUpdateRequest) GetImage() *v2.Image {
@@ -399,9 +408,11 @@ const file_metalstack_admin_v2_image_proto_rawDesc = "" +
 	"\x19ImageServiceCreateRequest\x12.\n" +
 	"\x05image\x18\x01 \x01(\v2\x18.metalstack.api.v2.ImageR\x05image\"L\n" +
 	"\x1aImageServiceCreateResponse\x12.\n" +
-	"\x05image\x18\x01 \x01(\v2\x18.metalstack.api.v2.ImageR\x05image\"K\n" +
-	"\x19ImageServiceUpdateRequest\x12.\n" +
-	"\x05image\x18\x01 \x01(\v2\x18.metalstack.api.v2.ImageR\x05image\"L\n" +
+	"\x05image\x18\x01 \x01(\v2\x18.metalstack.api.v2.ImageR\x05image\"g\n" +
+	"\x19ImageServiceUpdateRequest\x12\x1a\n" +
+	"\x02id\x18\x01 \x01(\tB\n" +
+	"\xbaH\ar\x05\x10\x02\x18\x80\x01R\x02id\x12.\n" +
+	"\x05image\x18\x02 \x01(\v2\x18.metalstack.api.v2.ImageR\x05image\"L\n" +
 	"\x1aImageServiceUpdateResponse\x12.\n" +
 	"\x05image\x18\x01 \x01(\v2\x18.metalstack.api.v2.ImageR\x05image\"7\n" +
 	"\x19ImageServiceDeleteRequest\x12\x1a\n" +

--- a/go/metalstack/admin/v2/partition.pb.go
+++ b/go/metalstack/admin/v2/partition.pb.go
@@ -72,8 +72,10 @@ func (x *PartitionServiceCreateRequest) GetPartition() *v2.Partition {
 // PartitionServiceUpdateRequest is the request payload for a partition update request
 type PartitionServiceUpdateRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
+	// The id of the partition to update
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Partition the partition
-	Partition     *v2.Partition `protobuf:"bytes,1,opt,name=partition,proto3" json:"partition,omitempty"`
+	Partition     *v2.Partition `protobuf:"bytes,2,opt,name=partition,proto3" json:"partition,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -106,6 +108,13 @@ func (x *PartitionServiceUpdateRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use PartitionServiceUpdateRequest.ProtoReflect.Descriptor instead.
 func (*PartitionServiceUpdateRequest) Descriptor() ([]byte, []int) {
 	return file_metalstack_admin_v2_partition_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *PartitionServiceUpdateRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
 }
 
 func (x *PartitionServiceUpdateRequest) GetPartition() *v2.Partition {
@@ -544,9 +553,11 @@ const file_metalstack_admin_v2_partition_proto_rawDesc = "" +
 	"\n" +
 	"#metalstack/admin/v2/partition.proto\x12\x13metalstack.admin.v2\x1a\x1bbuf/validate/validate.proto\x1a\x1emetalstack/api/v2/common.proto\x1a!metalstack/api/v2/partition.proto\"[\n" +
 	"\x1dPartitionServiceCreateRequest\x12:\n" +
-	"\tpartition\x18\x01 \x01(\v2\x1c.metalstack.api.v2.PartitionR\tpartition\"[\n" +
-	"\x1dPartitionServiceUpdateRequest\x12:\n" +
-	"\tpartition\x18\x01 \x01(\v2\x1c.metalstack.api.v2.PartitionR\tpartition\";\n" +
+	"\tpartition\x18\x01 \x01(\v2\x1c.metalstack.api.v2.PartitionR\tpartition\"w\n" +
+	"\x1dPartitionServiceUpdateRequest\x12\x1a\n" +
+	"\x02id\x18\x01 \x01(\tB\n" +
+	"\xbaH\ar\x05\x10\x02\x18\x80\x01R\x02id\x12:\n" +
+	"\tpartition\x18\x02 \x01(\v2\x1c.metalstack.api.v2.PartitionR\tpartition\";\n" +
 	"\x1dPartitionServiceDeleteRequest\x12\x1a\n" +
 	"\x02id\x18\x01 \x01(\tB\n" +
 	"\xbaH\ar\x05\x10\x02\x18\x80\x01R\x02id\"\\\n" +

--- a/go/metalstack/api/v2/ip.pb.go
+++ b/go/metalstack/api/v2/ip.pb.go
@@ -433,7 +433,7 @@ func (x *IPServiceCreateRequest) GetAddressFamily() IPAddressFamily {
 type IPServiceUpdateRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Ip the ip to update
-	Ip string `protobuf:"bytes,1,opt,name=ip,proto3" json:"ip,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Project of the ip
 	Project string `protobuf:"bytes,2,opt,name=project,proto3" json:"project,omitempty"`
 	// Name of this ip
@@ -478,9 +478,9 @@ func (*IPServiceUpdateRequest) Descriptor() ([]byte, []int) {
 	return file_metalstack_api_v2_ip_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *IPServiceUpdateRequest) GetIp() string {
+func (x *IPServiceUpdateRequest) GetId() string {
 	if x != nil {
-		return x.Ip
+		return x.Id
 	}
 	return ""
 }
@@ -1042,7 +1042,7 @@ const file_metalstack_api_v2_ip_proto_rawDesc = "" +
 	"\x05_typeB\x11\n" +
 	"\x0f_address_family\"\xd4\x02\n" +
 	"\x16IPServiceUpdateRequest\x12\x17\n" +
-	"\x02ip\x18\x01 \x01(\tB\a\xbaH\x04r\x02p\x01R\x02ip\x12\"\n" +
+	"\x02id\x18\x01 \x01(\tB\a\xbaH\x04r\x02p\x01R\x02id\x12\"\n" +
 	"\aproject\x18\x02 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\aproject\x12#\n" +
 	"\x04name\x18\x03 \x01(\tB\n" +
 	"\xbaH\ar\x05\x10\x02\x18\x80\x01H\x00R\x04name\x88\x01\x01\x12/\n" +

--- a/go/metalstack/api/v2/project.pb.go
+++ b/go/metalstack/api/v2/project.pb.go
@@ -725,14 +725,16 @@ func (x *ProjectServiceDeleteResponse) GetProject() *Project {
 // ProjectServiceUpdateRequest is the request payload to update a project
 type ProjectServiceUpdateRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Project is the uuid of the project to get
-	Project string `protobuf:"bytes,1,opt,name=project,proto3" json:"project,omitempty"`
+	// Id is the uuid of the project to update, must be equal to project
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	// Project is the uuid of the project to update
+	Project string `protobuf:"bytes,2,opt,name=project,proto3" json:"project,omitempty"`
 	// Name of this project unique per tenant
-	Name *string `protobuf:"bytes,2,opt,name=name,proto3,oneof" json:"name,omitempty"`
+	Name *string `protobuf:"bytes,3,opt,name=name,proto3,oneof" json:"name,omitempty"`
 	// Description of this project
-	Description *string `protobuf:"bytes,3,opt,name=description,proto3,oneof" json:"description,omitempty"`
+	Description *string `protobuf:"bytes,4,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	// Avatar URL of the project
-	AvatarUrl     *string `protobuf:"bytes,4,opt,name=avatar_url,json=avatarUrl,proto3,oneof" json:"avatar_url,omitempty"`
+	AvatarUrl     *string `protobuf:"bytes,5,opt,name=avatar_url,json=avatarUrl,proto3,oneof" json:"avatar_url,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -765,6 +767,13 @@ func (x *ProjectServiceUpdateRequest) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ProjectServiceUpdateRequest.ProtoReflect.Descriptor instead.
 func (*ProjectServiceUpdateRequest) Descriptor() ([]byte, []int) {
 	return file_metalstack_api_v2_project_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *ProjectServiceUpdateRequest) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
 }
 
 func (x *ProjectServiceUpdateRequest) GetProject() string {
@@ -1585,14 +1594,15 @@ const file_metalstack_api_v2_project_proto_rawDesc = "" +
 	"\x1bProjectServiceDeleteRequest\x12\"\n" +
 	"\aproject\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\aproject\"T\n" +
 	"\x1cProjectServiceDeleteResponse\x124\n" +
-	"\aproject\x18\x01 \x01(\v2\x1a.metalstack.api.v2.ProjectR\aproject\"\xe4\x01\n" +
-	"\x1bProjectServiceUpdateRequest\x12\"\n" +
-	"\aproject\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\aproject\x12\"\n" +
-	"\x04name\x18\x02 \x01(\tB\t\xbaH\x06r\x04\x10\x02\x18@H\x00R\x04name\x88\x01\x01\x121\n" +
-	"\vdescription\x18\x03 \x01(\tB\n" +
+	"\aproject\x18\x01 \x01(\v2\x1a.metalstack.api.v2.ProjectR\aproject\"\xfe\x01\n" +
+	"\x1bProjectServiceUpdateRequest\x12\x18\n" +
+	"\x02id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x02id\x12\"\n" +
+	"\aproject\x18\x02 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\aproject\x12\"\n" +
+	"\x04name\x18\x03 \x01(\tB\t\xbaH\x06r\x04\x10\x02\x18@H\x00R\x04name\x88\x01\x01\x121\n" +
+	"\vdescription\x18\x04 \x01(\tB\n" +
 	"\xbaH\ar\x05\x10\x02\x18\x80\x04H\x01R\vdescription\x88\x01\x01\x12\"\n" +
 	"\n" +
-	"avatar_url\x18\x04 \x01(\tH\x02R\tavatarUrl\x88\x01\x01B\a\n" +
+	"avatar_url\x18\x05 \x01(\tH\x02R\tavatarUrl\x88\x01\x01B\a\n" +
 	"\x05_nameB\x0e\n" +
 	"\f_descriptionB\r\n" +
 	"\v_avatar_url\"T\n" +

--- a/go/metalstack/api/v2/tenant.pb.go
+++ b/go/metalstack/api/v2/tenant.pb.go
@@ -500,8 +500,8 @@ func (x *TenantServiceCreateRequest) GetPhoneNumber() string {
 // TenantServiceUpdateRequest is the request payload of the tenant update request
 type TenantServiceUpdateRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Login of the tenant
-	Login string `protobuf:"bytes,1,opt,name=login,proto3" json:"login,omitempty"`
+	// Login of the tenant to update
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Name of the tenant
 	Name *string `protobuf:"bytes,2,opt,name=name,proto3,oneof" json:"name,omitempty"`
 	// Email of the tenant
@@ -544,9 +544,9 @@ func (*TenantServiceUpdateRequest) Descriptor() ([]byte, []int) {
 	return file_metalstack_api_v2_tenant_proto_rawDescGZIP(), []int{6}
 }
 
-func (x *TenantServiceUpdateRequest) GetLogin() string {
+func (x *TenantServiceUpdateRequest) GetId() string {
 	if x != nil {
-		return x.Login
+		return x.Id
 	}
 	return ""
 }
@@ -1600,9 +1600,9 @@ const file_metalstack_api_v2_tenant_proto_rawDesc = "" +
 	"\f_descriptionB\b\n" +
 	"\x06_emailB\r\n" +
 	"\v_avatar_urlB\x0f\n" +
-	"\r_phone_number\"\x83\x02\n" +
-	"\x1aTenantServiceUpdateRequest\x12\x14\n" +
-	"\x05login\x18\x01 \x01(\tR\x05login\x12\"\n" +
+	"\r_phone_number\"\xfd\x01\n" +
+	"\x1aTenantServiceUpdateRequest\x12\x0e\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12\"\n" +
 	"\x04name\x18\x02 \x01(\tB\t\xbaH\x06r\x04\x10\x02\x18@H\x00R\x04name\x88\x01\x01\x12\"\n" +
 	"\x05email\x18\x03 \x01(\tB\a\xbaH\x04r\x02`\x01H\x01R\x05email\x88\x01\x01\x121\n" +
 	"\vdescription\x18\x04 \x01(\tB\n" +

--- a/go/metalstack/api/v2/token.pb.go
+++ b/go/metalstack/api/v2/token.pb.go
@@ -576,7 +576,7 @@ func (*TokenServiceRevokeResponse) Descriptor() ([]byte, []int) {
 type TokenServiceUpdateRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Uuid of the token to update
-	Uuid string `protobuf:"bytes,1,opt,name=uuid,proto3" json:"uuid,omitempty"`
+	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Description is a user given description of this token.
 	Description *string `protobuf:"bytes,2,opt,name=description,proto3,oneof" json:"description,omitempty"`
 	// Permissions is a list of service methods this token can be used for
@@ -621,9 +621,9 @@ func (*TokenServiceUpdateRequest) Descriptor() ([]byte, []int) {
 	return file_metalstack_api_v2_token_proto_rawDescGZIP(), []int{8}
 }
 
-func (x *TokenServiceUpdateRequest) GetUuid() string {
+func (x *TokenServiceUpdateRequest) GetId() string {
 	if x != nil {
-		return x.Uuid
+		return x.Id
 	}
 	return ""
 }
@@ -859,9 +859,9 @@ const file_metalstack_api_v2_token_proto_rawDesc = "" +
 	"\x06tokens\x18\x01 \x03(\v2\x18.metalstack.api.v2.TokenR\x06tokens\"9\n" +
 	"\x19TokenServiceRevokeRequest\x12\x1c\n" +
 	"\x04uuid\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x04uuid\"\x1c\n" +
-	"\x1aTokenServiceRevokeResponse\"\xe2\x06\n" +
-	"\x19TokenServiceUpdateRequest\x12\x1c\n" +
-	"\x04uuid\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x04uuid\x121\n" +
+	"\x1aTokenServiceRevokeResponse\"\xde\x06\n" +
+	"\x19TokenServiceUpdateRequest\x12\x18\n" +
+	"\x02id\x18\x01 \x01(\tB\b\xbaH\x05r\x03\xb0\x01\x01R\x02id\x121\n" +
 	"\vdescription\x18\x02 \x01(\tB\n" +
 	"\xbaH\ar\x05\x10\x02\x18\x80\x02H\x00R\vdescription\x88\x01\x01\x12E\n" +
 	"\vpermissions\x18\x03 \x03(\v2#.metalstack.api.v2.MethodPermissionR\vpermissions\x12\xc1\x01\n" +

--- a/go/tests/api_scopes_test.go
+++ b/go/tests/api_scopes_test.go
@@ -9,8 +9,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	v2 "github.com/metal-stack/api/go/metalstack/api/v2"
 	"github.com/metal-stack/api/go/tests/protoparser"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
@@ -109,14 +112,20 @@ func Test_APIScopes(t *testing.T) {
 	err = validateProto("./testproto")
 
 	errs := errors.Join(
-		errors.New("api service method: \"/metalstack.api.v2.WrongProjectService/Get\" has apiv2.ProjectRole but request payload \"WrongProjectServiceGetRequest\" does not have a project field"),
-		errors.New("api service method: \"/metalstack.api.v2.WrongProjectService/List\" has no scope defined. one scope needs to be defined though. use one of the following scopes: [apiv2.AdminRole apiv2.InfraRole apiv2.ProjectRole apiv2.TenantRole apiv2.Visibility]"),
-		errors.New("api service method: \"/metalstack.api.v2.WrongProjectService/Update\" can not have apiv2.AdminRole ([ADMIN_ROLE_VIEWER]) and apiv2.ProjectRole ([PROJECT_ROLE_OWNER]) at the same time. only one scope is allowed."),
-		errors.New("api service method: \"/metalstack.api.v2.WrongProjectService/Delete\" can not have apiv2.AdminRole ([ADMIN_ROLE_VIEWER]) and apiv2.Visibility ([VISIBILITY_PUBLIC]) at the same time. only one scope is allowed."),
-		errors.New("api service method: \"/metalstack.api.v2.WrongProjectService/Charge\" has no scope defined. one scope needs to be defined though. use one of the following scopes: [apiv2.AdminRole apiv2.InfraRole apiv2.ProjectRole apiv2.TenantRole apiv2.Visibility]"),
+		errors.New("api service method: /metalstack.api.v2.WrongProjectService/Get has apiv2.ProjectRole but request payload WrongProjectServiceGetRequest does not have a project field"),
+		errors.New("api service method: /metalstack.api.v2.WrongProjectService/List has no scope defined. one scope needs to be defined though. use one of the following scopes: [apiv2.AdminRole apiv2.InfraRole apiv2.ProjectRole apiv2.TenantRole apiv2.Visibility]"),
+		errors.New("api service method: /metalstack.api.v2.WrongProjectService/Update does not have a getid field, request payload WrongProjectServiceUpdateRequest"),
+		errors.New("api service method: /metalstack.api.v2.WrongProjectService/Update can not have apiv2.AdminRole ([ADMIN_ROLE_VIEWER]) and apiv2.ProjectRole ([PROJECT_ROLE_OWNER]) at the same time. only one scope is allowed."),
+		errors.New("api service method: /metalstack.api.v2.WrongProjectService/Delete can not have apiv2.AdminRole ([ADMIN_ROLE_VIEWER]) and apiv2.Visibility ([VISIBILITY_PUBLIC]) at the same time. only one scope is allowed."),
+		errors.New("api service method: /metalstack.api.v2.WrongProjectService/Charge has no scope defined. one scope needs to be defined though. use one of the following scopes: [apiv2.AdminRole apiv2.InfraRole apiv2.ProjectRole apiv2.TenantRole apiv2.Visibility]"),
 	)
 
-	require.Equal(t, err, errs)
+	fmt.Printf("\n%s\n", errs.Error())
+
+	assert.Equal(t, err.Error(), errs.Error())
+	if diff := cmp.Diff(err.Error(), errs.Error(), cmpopts.EquateErrors()); diff != "" {
+		t.Errorf("diff = %s", diff)
+	}
 }
 
 func validateProto(root string) error {
@@ -174,11 +183,32 @@ func validateProto(root string) error {
 				// Sort all to have stable results
 				slices.Sort(allScopeNames)
 
+				for _, mt := range fd.GetMessageType() {
+					if mt.GetName() != method.GetInputType() {
+						continue
+					}
+					var (
+						isUpdateRequest bool
+						updateRequest   string
+					)
+					if strings.Contains(mt.GetName(), "UpdateRequest") {
+						for _, field := range mt.GetField() {
+							if field.GetName() == "id" {
+								isUpdateRequest = true
+							}
+						}
+						updateRequest = mt.GetName()
+						if !isUpdateRequest {
+							errs = append(errs, fmt.Errorf("api service method: %s does not have a getid field, request payload %s", methodName, updateRequest))
+						}
+					}
+				}
+
 				for _, name := range scopeKeys {
 					s := scopes[name]
 					if len(s) > 0 {
 						if methodScope != "" {
-							errs = append(errs, fmt.Errorf("api service method: %q can not have %s and %s (%s) at the same time. only one scope is allowed.", methodName, methodScope, name, s))
+							errs = append(errs, fmt.Errorf("api service method: %s can not have %s and %s (%s) at the same time. only one scope is allowed.", methodName, methodScope, name, s))
 						}
 						methodScope = fmt.Sprintf("%s (%s)", name, s)
 					}
@@ -198,13 +228,13 @@ func validateProto(root string) error {
 							projectRequest = mt.GetName()
 						}
 						if !projectFound {
-							errs = append(errs, fmt.Errorf("api service method: %q has %s but request payload %q does not have a project field", methodName, prs, projectRequest))
+							errs = append(errs, fmt.Errorf("api service method: %s has %s but request payload %s does not have a project field", methodName, prs, projectRequest))
 						}
 					}
 				}
 
 				if methodScope == "" {
-					errs = append(errs, fmt.Errorf("api service method: %q has no scope defined. one scope needs to be defined though. use one of the following scopes: %s", methodName, allScopeNames))
+					errs = append(errs, fmt.Errorf("api service method: %s has no scope defined. one scope needs to be defined though. use one of the following scopes: %s", methodName, allScopeNames))
 				}
 			}
 		}

--- a/go/tests/testproto/wrongproject.proto
+++ b/go/tests/testproto/wrongproject.proto
@@ -8,17 +8,17 @@ service WrongProjectService {
   rpc Get(WrongProjectServiceGetRequest) returns (WrongProjectServiceGetResponse) {
     option (project_roles) = PROJECT_ROLE_OWNER;
   }
-  rpc List(WrongProjectServiceGetRequest) returns (WrongProjectServiceGetResponse) {
+  rpc List(WrongProjectServiceListRequest) returns (WrongProjectServiceListResponse) {
   }
   rpc Update(WrongProjectServiceUpdateRequest) returns (WrongProjectServiceUpdateResponse) {
     option (admin_roles) = ADMIN_ROLE_VIEWER;
     option (project_roles) = PROJECT_ROLE_OWNER;
   }
-  rpc Delete(WrongProjectServiceUpdateRequest) returns (WrongProjectServiceUpdateResponse) {
+  rpc Delete(WrongProjectServiceDeleteRequest) returns (WrongProjectServiceDeleteResponse) {
     option (admin_roles) = ADMIN_ROLE_VIEWER;
     option (metalstack.api.v2.visibility) = VISIBILITY_PUBLIC;
   }
-  rpc Charge(WrongProjectServiceUpdateRequest) returns (WrongProjectServiceUpdateResponse) {
+  rpc Charge(WrongProjectServiceChargeRequest) returns (WrongProjectServiceChargeResponse) {
     option (chargeable) = CHARGEABLE_TRUE;
   }
 }
@@ -30,11 +30,33 @@ message WrongProjectServiceGetRequest {
 message WrongProjectServiceGetResponse {
     string uuid = 1;
 }
+message WrongProjectServiceListRequest {
+    string uuid = 1;
+}
+
+message WrongProjectServiceListResponse {
+    string uuid = 1;
+}
+
 message WrongProjectServiceUpdateRequest {
     string uuid = 1;
     string project = 2;
 }
-
 message WrongProjectServiceUpdateResponse {
+    string uuid = 1;
+}
+
+message WrongProjectServiceDeleteRequest {
+    string uuid = 1;
+}
+
+message WrongProjectServiceDeleteResponse {
+    string uuid = 1;
+}
+message WrongProjectServiceChargeRequest {
+    string uuid = 1;
+}
+
+message WrongProjectServiceChargeResponse {
     string uuid = 1;
 }

--- a/proto/metalstack/admin/v2/filesystem.proto
+++ b/proto/metalstack/admin/v2/filesystem.proto
@@ -39,8 +39,13 @@ message FilesystemServiceCreateResponse {
 
 // FilesystemServiceUpdateRequest
 message FilesystemServiceUpdateRequest {
+  // Id of the filesystemLayout to update
+  string id = 1 [(buf.validate.field).string = {
+    min_len: 2
+    max_len: 128
+  }];
   // FilesystemLayout the filesystemlayout
-  metalstack.api.v2.FilesystemLayout filesystem_layout = 1;
+  metalstack.api.v2.FilesystemLayout filesystem_layout = 2;
 }
 
 // FilesystemServiceUpdateResponse

--- a/proto/metalstack/admin/v2/image.proto
+++ b/proto/metalstack/admin/v2/image.proto
@@ -44,8 +44,13 @@ message ImageServiceCreateResponse {
 
 // ImageServiceUpdateRequest
 message ImageServiceUpdateRequest {
+  // Id of the imageLayout to update
+  string id = 1 [(buf.validate.field).string = {
+    min_len: 2
+    max_len: 128
+  }];
   // Image is the image
-  metalstack.api.v2.Image image = 1;
+  metalstack.api.v2.Image image = 2;
 }
 
 // ImageServiceUpdateResponse

--- a/proto/metalstack/admin/v2/partition.proto
+++ b/proto/metalstack/admin/v2/partition.proto
@@ -39,8 +39,13 @@ message PartitionServiceCreateRequest {
 
 // PartitionServiceUpdateRequest is the request payload for a partition update request
 message PartitionServiceUpdateRequest {
+  // The id of the partition to update
+  string id = 1 [(buf.validate.field).string = {
+    min_len: 2
+    max_len: 128
+  }];
   // Partition the partition
-  metalstack.api.v2.Partition partition = 1;
+  metalstack.api.v2.Partition partition = 2;
 }
 
 // PartitionServiceDeleteRequest is the request payload for a partition delete request

--- a/proto/metalstack/api/v2/ip.proto
+++ b/proto/metalstack/api/v2/ip.proto
@@ -128,7 +128,7 @@ message IPServiceCreateRequest {
 // IPServiceUpdateRequest is the request payload for a ip update request
 message IPServiceUpdateRequest {
   // Ip the ip to update
-  string ip = 1 [(buf.validate.field).string.ip = true];
+  string id = 1 [(buf.validate.field).string.ip = true];
   // Project of the ip
   string project = 2 [(buf.validate.field).string.uuid = true];
   // Name of this ip

--- a/proto/metalstack/api/v2/project.proto
+++ b/proto/metalstack/api/v2/project.proto
@@ -203,20 +203,22 @@ message ProjectServiceDeleteResponse {
 
 // ProjectServiceUpdateRequest is the request payload to update a project
 message ProjectServiceUpdateRequest {
-  // Project is the uuid of the project to get
-  string project = 1 [(buf.validate.field).string.uuid = true];
+  // Id is the uuid of the project to update, must be equal to project
+  string id = 1 [(buf.validate.field).string.uuid = true];
+  // Project is the uuid of the project to update
+  string project = 2 [(buf.validate.field).string.uuid = true];
   // Name of this project unique per tenant
-  optional string name = 2 [(buf.validate.field).string = {
+  optional string name = 3 [(buf.validate.field).string = {
     min_len: 2
     max_len: 64
   }];
   // Description of this project
-  optional string description = 3 [(buf.validate.field).string = {
+  optional string description = 4 [(buf.validate.field).string = {
     min_len: 2
     max_len: 512
   }];
   // Avatar URL of the project
-  optional string avatar_url = 4;
+  optional string avatar_url = 5;
 }
 
 // ProjectServiceUpdateResponse is the response payload to update a project

--- a/proto/metalstack/api/v2/tenant.proto
+++ b/proto/metalstack/api/v2/tenant.proto
@@ -169,8 +169,8 @@ message TenantServiceCreateRequest {
 
 // TenantServiceUpdateRequest is the request payload of the tenant update request
 message TenantServiceUpdateRequest {
-  // Login of the tenant
-  string login = 1;
+  // Login of the tenant to update
+  string id = 1;
   // Name of the tenant
   optional string name = 2 [(buf.validate.field).string = {
     min_len: 2

--- a/proto/metalstack/api/v2/token.proto
+++ b/proto/metalstack/api/v2/token.proto
@@ -162,7 +162,7 @@ message TokenServiceRevokeResponse {}
 // TokenServiceUpdateRequest is the request payload of a token update request
 message TokenServiceUpdateRequest {
   // Uuid of the token to update
-  string uuid = 1 [(buf.validate.field).string.uuid = true];
+  string id = 1 [(buf.validate.field).string.uuid = true];
   // Description is a user given description of this token.
   optional string description = 2 [(buf.validate.field).string = {
     min_len: 2


### PR DESCRIPTION
## Description

As suggested by @Gerrit91, this would simplify the repository logic a lot.

Downside is that the `ProjectServiceUpdateRequest` contains a `project` and a `id` field which must be identical

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
