### PR TITLE
Detect UpdateRequests which do not specify a updated_at field

### DIFF
--- a/go/tests/api_scopes_test.go
+++ b/go/tests/api_scopes_test.go
@@ -112,6 +112,7 @@ func Test_APIScopes(t *testing.T) {
 		errors.New("api service method: \"/metalstack.api.v2.WrongProjectService/Add\" has apiv2.TenantRole but request payload \"WrongProjectServiceAddRequest\" does not have a login field"),
 		errors.New("api service method: \"/metalstack.api.v2.WrongProjectService/Get\" has apiv2.ProjectRole but request payload \"WrongProjectServiceGetRequest\" does not have a project field"),
 		errors.New("api service method: \"/metalstack.api.v2.WrongProjectService/List\" has no scope defined. one scope needs to be defined though. use one of the following scopes: [apiv2.AdminRole apiv2.InfraRole apiv2.ProjectRole apiv2.TenantRole apiv2.Visibility]"),
+		errors.New("api service method: \"/metalstack.api.v2.WrongProjectService/Update\" does not have a updated_at field in WrongProjectServiceUpdateRequest"),
 		errors.New("api service method: \"/metalstack.api.v2.WrongProjectService/Update\" can not have apiv2.AdminRole ([ADMIN_ROLE_VIEWER]) and apiv2.ProjectRole ([PROJECT_ROLE_OWNER]) at the same time. only one scope is allowed."),
 		errors.New("api service method: \"/metalstack.api.v2.WrongProjectService/Delete\" can not have apiv2.AdminRole ([ADMIN_ROLE_VIEWER]) and apiv2.Visibility ([VISIBILITY_PUBLIC]) at the same time. only one scope is allowed."),
 		errors.New("api service method: \"/metalstack.api.v2.WrongProjectService/Charge\" has no scope defined. one scope needs to be defined though. use one of the following scopes: [apiv2.AdminRole apiv2.InfraRole apiv2.ProjectRole apiv2.TenantRole apiv2.Visibility]"),
@@ -174,6 +175,29 @@ func validateProto(root string) error {
 
 				// Sort all to have stable results
 				slices.Sort(allScopeNames)
+
+				for _, mt := range fd.GetMessageType() {
+					if mt.GetName() != method.GetInputType() {
+						continue
+					}
+					var (
+						updateRequest string
+					)
+					if strings.Contains(mt.GetName(), "UpdateRequest") {
+						var (
+							hasUpdatedAtField bool
+						)
+						for _, field := range mt.GetField() {
+							if field.GetName() == "updated_at" {
+								hasUpdatedAtField = true
+							}
+						}
+						updateRequest = mt.GetName()
+						if !hasUpdatedAtField {
+							errs = append(errs, fmt.Errorf("api service method: %q does not have a updated_at field in %s", methodName, updateRequest))
+						}
+					}
+				}
 
 				for _, name := range scopeKeys {
 					s := scopes[name]

--- a/proto/Makefile
+++ b/proto/Makefile
@@ -1,5 +1,5 @@
 MAKEFLAGS += --no-print-directory
-BUF_VERSION := 1.57.0
+BUF_VERSION := 1.57.2
 
 _buf:
 	docker run --rm \


### PR DESCRIPTION
## Description

This check was missing in #43, now it works

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
