### PR TITLE
Add ability to configure client from env variables

### DIFF
--- a/go/client/conn.go
+++ b/go/client/conn.go
@@ -5,13 +5,19 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
+	"os"
 	"time"
 
 	"connectrpc.com/connect"
 	"github.com/golang-jwt/jwt/v5"
 )
 
-const tokenRenewChecksDuringLifetime = 4
+const (
+	tokenRenewChecksDuringLifetime = 4
+	TokenEnvName                   = "METAL_APIV2_TOKEN"
+	BaseURLEnvName                 = "METAL_APIV2_URL"
+)
 
 type (
 	// DialConfig is the configuration to create a api-server connection
@@ -55,9 +61,23 @@ func (d *DialConfig) HttpClient() *http.Client {
 }
 
 func (dc *DialConfig) parse() error {
-	if dc.Token == "" {
-		return nil
+	if dc.BaseURL == "" {
+		dc.BaseURL = os.Getenv(BaseURLEnvName)
+		if dc.BaseURL == "" {
+			return fmt.Errorf("neither BaseURL nor %s were given", BaseURLEnvName)
+		}
+		if _, err := url.Parse(dc.BaseURL); err != nil {
+			return err
+		}
 	}
+
+	if dc.Token == "" {
+		dc.Token = os.Getenv(TokenEnvName)
+		if dc.Token == "" {
+			return nil
+		}
+	}
+
 	parsed, err := jwt.Parse(dc.Token, nil)
 	if err != nil && !errors.Is(err, jwt.ErrTokenUnverifiable) {
 		return fmt.Errorf("unable to parse token:%w", err)
@@ -80,5 +100,6 @@ func (dc *DialConfig) parse() error {
 	if dc.issuedAt.IsZero() {
 		dc.issuedAt = time.Now()
 	}
+
 	return nil
 }


### PR DESCRIPTION
## Description

Can now be done with these two variables:

- "METAL_APIV2_TOKEN"
- "METAL_APIV2_URL"

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
