### PR TITLE
Document order of ips on loopback

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -9905,7 +9905,8 @@ should be in the form &lt;ip|host&gt;:&lt;port&gt; </p></td>
                   <td>networks</td>
                   <td><a href="#metalstack.api.v2.MachineNetwork">MachineNetwork</a></td>
                   <td>repeated</td>
-                  <td><p>Networks this machine should be attached to </p></td>
+                  <td><p>Networks this machine should be attached to
+Order of ips of external networks will be preserved. </p></td>
                 </tr>
               
                 <tr>
@@ -9994,7 +9995,8 @@ AWS limits the max userdata size to 16k, lets allow twice as much </p></td>
                   <td><a href="#string">string</a></td>
                   <td>repeated</td>
                   <td><p>IPs to to attach to this machine additionally
-If none given, one ip address is acquired per network for the machine </p></td>
+If none given, one ip address is acquired per network for the machine
+Order of ips is preserved on the loopback interface. </p></td>
                 </tr>
               
             </tbody>

--- a/go/metalstack/api/v2/machine.pb.go
+++ b/go/metalstack/api/v2/machine.pb.go
@@ -1703,6 +1703,7 @@ type MachineAllocation struct {
 	// FilesystemLayout to create on the disks
 	FilesystemLayout *FilesystemLayout `protobuf:"bytes,8,opt,name=filesystem_layout,json=filesystemLayout,proto3" json:"filesystem_layout,omitempty"`
 	// Networks this machine should be attached to
+	// Order of ips of external networks will be preserved.
 	Networks []*MachineNetwork `protobuf:"bytes,9,rep,name=networks,proto3" json:"networks,omitempty"`
 	// Hostname of the allocated machine
 	Hostname string `protobuf:"bytes,10,opt,name=hostname,proto3" json:"hostname,omitempty"`
@@ -1881,6 +1882,7 @@ type MachineAllocationNetwork struct {
 	Network string `protobuf:"bytes,1,opt,name=network,proto3" json:"network,omitempty"`
 	// IPs to to attach to this machine additionally
 	// If none given, one ip address is acquired per network for the machine
+	// Order of ips is preserved on the loopback interface.
 	Ips           []string `protobuf:"bytes,2,rep,name=ips,proto3" json:"ips,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/go/tests/validation/common.go
+++ b/go/tests/validation/common.go
@@ -27,14 +27,6 @@ func createString(n int) string {
 	return string(s)
 }
 
-func createRepeatedString(n int) []string {
-	arr := make([]string, n)
-	for i := range arr {
-		arr[i] = "opt" + string(rune('a'+(i%26)))
-	}
-	return arr
-}
-
 func createDiskDevices(n int) []string {
 	devs := make([]string, n)
 	for i := range devs {

--- a/go/tests/validation/filesystem_test.go
+++ b/go/tests/validation/filesystem_test.go
@@ -157,18 +157,6 @@ func TestValidateFilesystem(t *testing.T) {
 			wantErrorMessage: "validation error: mount_options: repeated value must contain unique items",
 		},
 		{
-			name: "Invalid Filesystem, mount_options more than 32 items",
-			msg: &apiv2.Filesystem{
-				Device:       "/dev/sda3",
-				Format:       apiv2.Format_FORMAT_EXT4,
-				MountOptions: createRepeatedString(33),
-			},
-			wantErr: true,
-			wantErrorMessage: `validation errors:
- - mount_options: must contain no more than 32 item(s)
- - mount_options: repeated value must contain unique items`,
-		},
-		{
 			name: "Invalid Filesystem, mount_options item too long",
 			msg: &apiv2.Filesystem{
 				Device:       "/dev/sda3",

--- a/js/metalstack/api/v2/machine_pb.d.ts
+++ b/js/metalstack/api/v2/machine_pb.d.ts
@@ -648,6 +648,7 @@ export type MachineAllocation = Message<"metalstack.api.v2.MachineAllocation"> &
     filesystemLayout?: FilesystemLayout | undefined;
     /**
      * Networks this machine should be attached to
+     * Order of ips of external networks will be preserved.
      *
      * @generated from field: repeated metalstack.api.v2.MachineNetwork networks = 9;
      */
@@ -722,6 +723,7 @@ export type MachineAllocationNetwork = Message<"metalstack.api.v2.MachineAllocat
     /**
      * IPs to to attach to this machine additionally
      * If none given, one ip address is acquired per network for the machine
+     * Order of ips is preserved on the loopback interface.
      *
      * @generated from field: repeated string ips = 2;
      */

--- a/js/metalstack/api/v2/machine_pb.ts
+++ b/js/metalstack/api/v2/machine_pb.ts
@@ -770,6 +770,7 @@ export type MachineAllocation = Message<"metalstack.api.v2.MachineAllocation"> &
 
   /**
    * Networks this machine should be attached to
+   * Order of ips of external networks will be preserved.
    *
    * @generated from field: repeated metalstack.api.v2.MachineNetwork networks = 9;
    */
@@ -856,6 +857,7 @@ export type MachineAllocationNetwork = Message<"metalstack.api.v2.MachineAllocat
   /**
    * IPs to to attach to this machine additionally
    * If none given, one ip address is acquired per network for the machine
+   * Order of ips is preserved on the loopback interface.
    *
    * @generated from field: repeated string ips = 2;
    */

--- a/proto/metalstack/api/v2/machine.proto
+++ b/proto/metalstack/api/v2/machine.proto
@@ -305,6 +305,7 @@ message MachineAllocation {
   // FilesystemLayout to create on the disks
   FilesystemLayout filesystem_layout = 8;
   // Networks this machine should be attached to
+  // Order of ips of external networks will be preserved.
   repeated MachineNetwork networks = 9;
   // Hostname of the allocated machine
   string hostname = 10 [(buf.validate.field).string.hostname = true];
@@ -343,6 +344,7 @@ message MachineAllocationNetwork {
   string network = 1 [(buf.validate.field).string.(metalstack.api.v2.is_name) = true];
   // IPs to to attach to this machine additionally
   // If none given, one ip address is acquired per network for the machine
+  // Order of ips is preserved on the loopback interface.
   repeated string ips = 2 [(buf.validate.field).repeated.(metalstack.api.v2.ips) = true];
 }
 


### PR DESCRIPTION
## Description

The order of additional ips matters, only the first ip is used for default routes.

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- none used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
